### PR TITLE
Documentation clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ or an object literal with the following properties:
    (either *count* or *foreach* is required)
 * `index` the name of the property that will store the index (default is `$index`)
 * `item` the name of the property used to access the indexed item in the array (default is `$item`)
-   (*item* is only used when an array is supplied with *foreach*) `$item` is a psuedo-observable and
+   (*item* is only used when an array is supplied with *foreach*) `$item` is a pseudo-observable and
    can be passed directly to bindings that accept observables (most do) or the item value can be
    accessed using observable syntax: `$item()`.
 * `bind` the binding used for the repeated elements (optional); *index* and *item* will be available
@@ -78,19 +78,19 @@ You may use `with` to create a binding context in a `repeat` to get the equivale
 ```html
 <div data-bind="repeat: availableCountries"
      data-repeat-bind="css: { sel: $item() == selectedCountry() }">
-    <span data-bind="text: $item, click: function() { select($item()); }"></span>
+    <span data-bind="text: $item, click: function() { selectedCountry($item()); }"></span>
 </div>
 ```
 ```html
 <div data-bind="repeat: availableCountries"
      data-repeat-bind="css: { sel: $item() == selectedCountry() }, with: $item">
-    <span data-bind="text: $data, click: select"></span>
+    <span data-bind="text: $data, click: $parent.selectedCountry"></span>
 </div>
 ```
 ```html
 <!-- ko foreach: availableCountries -->
 <div data-bind="css: { sel: $data == $parent.selectedCountry() }">
-    <span data-bind="text: $data, click: select"></span>
+    <span data-bind="text: $data, click: $parent.selectedCountry"></span>
 </div>
 <!-- /ko -->
 ```


### PR DESCRIPTION
I think it would be helpful to explain the main differences between `repeat` and `foreach` near the top of the readme. Something like this:

> `repeat` can replace `foreach` in many instances and is faster and simpler for some tasks. In contrast to `foreach`:
> - `repeat` does not create a binding context. Therefore, the variables for the binding context (`$data`, `$parent`, and `$parents`) are unaffected. Instead, you can access the current item using `$item()` and `$index`.
> - `repeat` operates on the outer HTML instead of the inner HTML.
> - `repeat` can either loop a number of times (`count`) or iterate over an array or observableArray (`foreach`).

Also it would be nice to have example showing the use of `with`, `$item()` as a function, and a function without arguments using `$item()` within a `repeat`:

> You may use `with` to create a binding context in a `repeat` to get the equivalent functionality of a `foreach`. These three examples are equivalent:
> 
> ``` html
> <div data-bind="repeat: availableCountries"
>      data-repeat-bind="css: { sel: $item() == selectedCountry() }">
>     <span data-bind="text: $item, click: function() { select($item()); }"></span>
> </div>
> ```
> 
> ``` html
> <div data-bind="repeat: availableCountries"
>      data-repeat-bind="css: { sel: $item() == selectedCountry() }, with: $item">
>     <span data-bind="text: $data, click: select"></span>
> </div>
> ```
> 
> ``` html
> <!-- ko foreach: availableCountries -->
> <div data-bind="css: { sel: $data == $parent.selectedCountry() }">
>     <span data-bind="text: $data, click: select"></span>
> </div>
> <!-- /ko -->
> ```
